### PR TITLE
Fix macOS precompiled NIF file extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,6 @@ jobs:
           LIB_EXTENSION="so"
           case ${{ matrix.job.target }} in
             *-pc-windows-*) LIB_EXTENSION="dll" ;;
-            *-apple-darwin) LIB_EXTENSION="dylib" ;;
           esac
           
           BUILT_LIB="target/${{ matrix.job.target }}/release/${LIB_PREFIX}ex_jsonschema.${LIB_EXTENSION}"
@@ -98,7 +97,6 @@ jobs:
           LIB_EXTENSION="so"
           case ${{ matrix.job.target }} in
             *-pc-windows-*) LIB_EXTENSION="dll" ;;
-            *-apple-darwin) LIB_EXTENSION="dylib" ;;
           esac
           
           ARCHIVE_NAME="libex_jsonschema-v${{ env.PROJECT_VERSION }}-nif-${{ matrix.nif }}-${{ matrix.job.target }}.${LIB_EXTENSION}.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2024-12-17
+
+### Fixed
+
+- Fixed precompiled NIF file extension for macOS targets - now correctly uses `.so` instead of `.dylib` to match Erlang/OTP conventions
+- Updated release workflow to generate correct file names for macOS precompiled binaries
+
 ## [0.1.0] - 2024-12-17
 
 ### Added
@@ -35,5 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Supports multiple architectures: x86_64 and aarch64 for macOS, Linux, and Windows
 - Optimized for performance with compile-once, validate-many pattern
 
-[Unreleased]: https://github.com/hassox/ex_jsonschema/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/hassox/ex_jsonschema/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/hassox/ex_jsonschema/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/hassox/ex_jsonschema/releases/tag/v0.1.0 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExJsonschema.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
   @source_url "https://github.com/hassox/ex_jsonschema"
   @description "High-performance JSON Schema validation for Elixir using Rust"
 


### PR DESCRIPTION
- Changed macOS builds to use .so extension instead of .dylib
- This matches Erlang/OTP conventions for NIFs on Unix-like systems
- Fixes issue where rustler_precompiled couldn't find macOS binaries
- Bump version to 0.1.1