### PR TITLE
Update Rustler to v0.36.2 and fix NIF version configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           nif-version: ${{ matrix.nif }}
           use-cross: false
           project-dir: "native/ex_jsonschema"
+          features: "nif_version_${{ matrix.nif }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/native/ex_jsonschema/.cargo/config.toml
+++ b/native/ex_jsonschema/.cargo/config.toml
@@ -2,4 +2,8 @@
 rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
 
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"] 
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+# See https://github.com/rust-lang/rust/issues/59302
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"] 

--- a/native/ex_jsonschema/Cargo.toml
+++ b/native/ex_jsonschema/Cargo.toml
@@ -8,10 +8,12 @@ name = "ex_jsonschema"
 crate-type = ["cdylib"]
 
 [dependencies]
-rustler = "0.36"
+rustler = { version = "0.36.2", default-features = false }
 jsonschema = "0.33"
 serde_json = "1.0"
 thiserror = "1.0"
 
 [features]
-default = [] 
+default = ["nif_version_2_15"]
+nif_version_2_15 = ["rustler/nif_version_2_15"]
+nif_version_2_17 = ["rustler/nif_version_2_17"] 


### PR DESCRIPTION
- Update rustler dependency to latest version 0.36.2
- Add proper NIF version features for 2.15 and 2.17 compatibility
- Configure rustler with default-features = false for better control
- Add features parameter to GitHub Actions build step
- Update .cargo/config.toml with Linux musl target configuration
- Fix "Missing setup of NIF features" error in CI

This resolves the precompilation issues by following the updated rustler_precompiled guide requirements since Rustler v0.30.0.

🤖 Generated with [Claude Code](https://claude.ai/code)