### PR TITLE
Follow proven patterns from Explorer/FastRSS for precompiled NIFs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,13 @@ jobs:
       matrix:
         include:
           - elixir: '1.17'
+            otp: '25'
+          - elixir: '1.17'
             otp: '26'
           - elixir: '1.17'
             otp: '27'
+          - elixir: '1.18'
+            otp: '25'
           - elixir: '1.18'
             otp: '26'
           - elixir: '1.18'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nif: ["2.17"]
+        nif: ["2.16", "2.15"]
         job:
-          - { target: aarch64-apple-darwin   , os: macos-14       }
+          - { target: aarch64-apple-darwin   , os: macos-13       }
           - { target: x86_64-apple-darwin    , os: macos-13       }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-22.04 }
-          - { target: x86_64-pc-windows-msvc, os: windows-2022   }
+          - { target: x86_64-pc-windows-msvc, os: windows-2019   }
 
     steps:
       - name: Checkout source code
@@ -52,7 +52,8 @@ jobs:
           project-version: ${{ env.PROJECT_VERSION }}
           target: ${{ matrix.job.target }}
           nif-version: ${{ matrix.nif }}
-          use-cross: false
+          use-cross: ${{ matrix.job.use-cross || false }}
+          cross-version: ${{ matrix.job.cross-version || 'from-source' }}
           project-dir: "native/ex_jsonschema"
 
       - name: Upload artifacts

--- a/native/ex_jsonschema/Cargo.toml
+++ b/native/ex_jsonschema/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0"
 thiserror = "1.0"
 
 [features]
-default = ["nif_version_2_17"]
+default = ["nif_version_2_16"]
 nif_version_2_15 = ["rustler/nif_version_2_15"]
 nif_version_2_16 = ["rustler/nif_version_2_16"]
 nif_version_2_17 = ["rustler/nif_version_2_17"] 


### PR DESCRIPTION
- Use NIF 2.16/2.15 matrix (like Explorer) instead of 2.17
- Switch to dynamic cross compilation settings matching successful projects
- Use older runner versions that are proven to work (macos-13, windows-2019)
- Add OTP 25 back since NIF 2.16 should support it
- Set default NIF version to 2.16 to match release matrix

This follows the exact patterns used by elixir-explorer/explorer and avencera/fast_rss which both build successfully across platforms.

🤖 Generated with [Claude Code](https://claude.ai/code)